### PR TITLE
Use Ax-b for primal update rather than Az-b

### DIFF
--- a/src/admm.jl
+++ b/src/admm.jl
@@ -200,9 +200,10 @@ function compute_rhs!(solver::MLSolver, options::SolverOptions)
     
     # Recompute pred = Ax - b with xᵏ instead of zᵏ (used in residuals)
     # TODO: maybe store pred w xk and pred with zk separately? 
-    mul!(solver.pred, solver.data.Adata, solver.xk)
-    solver.cache.vN .= solver.pred
-    solver.pred .-= solver.data.bdata
+    # NOTE: Removed below; update pred earlier in update!(MLSolver, ...)
+    # mul!(solver.pred, solver.data.Adata, solver.xk)
+    # solver.cache.vN .= solver.pred
+    # solver.pred .-= solver.data.bdata
 
     # compute first term (hessian)
     # λ₂xᵏ from the Hessian and λ₂xᵏ from the gradient cancel out
@@ -252,7 +253,6 @@ function update_x!(
     T = eltype(solver.xk)
 
     # update linear operator, i.e., ∇²f(xᵏ)
-    @bp
     update!(solver.lhs_op.Hf_xk, solver)
 
     # RHS = ∇²f(xᵏ)xᵏ - ∇f(xᵏ) - ρAᵀ(zᵏ - c + uᵏ)

--- a/src/admm.jl
+++ b/src/admm.jl
@@ -139,6 +139,10 @@ function obj_val!(solver::MLSolver, options::SolverOptions)
     solver.loss = sum(solver.data.f, solver.pred)
     solver.obj_val = solver.loss + 
         solver.λ1*norm(solver.zk, 1) + (solver.λ2/2)*sum(abs2, solver.zk)
+
+    # --- CALEB: Re-compute pred=Axk-b ---
+    mul!(solver.pred, solver.data.Adata, solver.xk)
+    solver.pred .-= solver.data.bdata
 end
 
 function obj_val!(solver::ConicSolver, options::SolverOptions)

--- a/src/linsys.jl
+++ b/src/linsys.jl
@@ -65,11 +65,6 @@ function RandomizedPreconditioners.NystromSketch(H::MLHessianOperator, r::Int; n
 end
 
 function update!(H::MLHessianOperator, solver)
-    # Re-compute pred=Ax-b
-    mul!(solver.pred, solver.data.Adata, solver.xk)
-    solver.cache.vN .= solver.pred
-    solver.pred .-= solver.data.bdata
-
     @. H.w = solver.data.d2f(solver.pred)
     return nothing
 end

--- a/src/linsys.jl
+++ b/src/linsys.jl
@@ -65,6 +65,11 @@ function RandomizedPreconditioners.NystromSketch(H::MLHessianOperator, r::Int; n
 end
 
 function update!(H::MLHessianOperator, solver)
+    # Re-compute pred=Ax-b
+    mul!(solver.pred, solver.data.Adata, solver.xk)
+    solver.cache.vN .= solver.pred
+    solver.pred .-= solver.data.bdata
+
     @. H.w = solver.data.d2f(solver.pred)
     return nothing
 end


### PR DESCRIPTION
The goal is to test what happens when the primal update uses the residual `Axk-b` rather than `Azk-b` (see [code](https://github.com/jucaleb4/GeNIOS.jl/blob/04698a3c4bc33815f527e0e50b4b4a1056831797/src/admm.jl#L133))